### PR TITLE
implement export methods removal (not for merge)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,25 +1,36 @@
 on: workflow_dispatch
 
-name: Publish Crates.io CI
+name: Publish plugin
 
 jobs:
-    build_and_test:
-        name: Build and test
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: stable
-            - uses: actions-rs/cargo@v1
-              with:
-                  command: build
-                  args: --release --all-features
-            - name: test
-              shell: bash
-              run: cargo test
-            - name: publish
-              shell: bash
-              run: cargo publish
-              env:
-                  CARGO_REGISTRY_TOKEN: "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+  build_and_test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2023-02-08
+          target: wasm32-wasi
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all-features
+      - name: test
+        run: cargo test
+      - name: rust target add
+        run: |
+          rustup target add wasm32-wasi
+          rustup target add wasm32-unknown-unknown
+      - name: build
+        run: make build-lib
+      - name: publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2023-02-08
-          target: wasm32-wasi
+          toolchain: 1.66.0
+          # target: wasm32-wasi
           override: true
       - uses: actions-rs/cargo@v1
         with:

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,6 @@
 {
-  "useTabs": false,
-  "tabWidth": 4,
-  "printWidth": 100,
-  "endOfLine": "lf"
+    "useTabs": false,
+    "tabWidth": 2,
+    "printWidth": 100,
+    "endOfLine": "lf"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "swc-plugin-hello"
-version = "0.1.7"
+version = "0.1.10"
 dependencies = [
  "serde",
  "swc_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
+checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
 
 [[package]]
 name = "glob"
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d864c91689fdc196779b98dba0aceac6118594c2df6ee5d943eb6a8df4d107a"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "memchr",
 ]
@@ -739,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
 dependencies = [
  "cfg-if",
  "libc",
@@ -873,9 +873,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
  "unicode-ident",
 ]
@@ -950,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1160,17 +1160,16 @@ checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
 
 [[package]]
 name = "sourcemap"
-version = "6.2.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c46fdc1838ff49cf692226f5c2b0f5b7538f556863d0eca602984714667ac6e7"
+checksum = "aebe057d110ddba043708da3fb010bf562ff6e9d4d60c9ee92860527bcbeccd6"
 dependencies = [
  "base64",
  "if_chain",
- "lazy_static",
- "regex",
  "rustc_version",
  "serde",
  "serde_json",
+ "unicode-id",
  "url",
 ]
 
@@ -1284,9 +1283,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.29.27"
+version = "0.29.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a2c285d33b47a5e532a662c178dc91956534ff52207892918d3034a534ae12"
+checksum = "4627e86f60ca7b81dbd2cfa571870236ffaae5c79920639b42935e94826c9b2c"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1317,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.53.0"
+version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0626aa233b7b966907f6d8aaa10de39c14f7e71d6ff26bad8bb9cfd6e146f7"
+checksum = "8dca0a0e3c0eb88f2a4788078dbad7c6d18ce9c0081d93600032f2aa4dba17c4"
 dependencies = [
  "once_cell",
  "swc_atoms",
@@ -1336,9 +1335,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.95.11"
+version = "0.96.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e5ff66d8aa3c21c32ffcdd871712f78a50819118690ba8195974d665d008b4"
+checksum = "7d7d0ce5a6462815ef8cb549f1be100c95c599171777398f32bbf275969f9518"
 dependencies = [
  "bitflags",
  "is-macro",
@@ -1354,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.128.18"
+version = "0.129.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb5143ce3b7089539fb55875a43b6111e4e1af1bb505e54c9cd4095ce12ab09"
+checksum = "007ecd4d3b1fa3c08d6c226d9905d88abb9b97105efba182478da6d0d55d5eac"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -1386,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.123.16"
+version = "0.124.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928c148fee43281df26871a2d1f242092734622e70aa3ea7ad474723537c702d"
+checksum = "855e61613186afae0344ebf602b0c83bc4227f262ef63e5fae1e503077ea0abf"
 dependencies = [
  "either",
  "enum_kind",
@@ -1417,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.112.23"
+version = "0.116.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b02196ab4fa800b761fee28f0e0549de3fbb09dfc05016de1d59c668fef3ead2"
+checksum = "7bae98277e96f4b4b98d41c277cc8645dc7b86dc85ac0f3c83575ae12a6068cb"
 dependencies = [
  "better_scoped_tls",
  "bitflags",
@@ -1439,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.115.24"
+version = "0.119.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b14ee57e200dfc554659a65986d186c3623f5f4c48bc18d9c6478e2cfce20ed"
+checksum = "a1de89253e3859306997c75adcce0ea8b9032ea488f3027eb4d70090334a5b80"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1465,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.106.18"
+version = "0.107.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdb27e68d2c658204efd98c506ea2ecf942737b513f5b2140b8d81d04fcedc1"
+checksum = "4cc62641e475f0cfdef0b63f4f68a94b8762109cd92a0382f69e5d74be5afd5b"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -1483,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.81.11"
+version = "0.82.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeee9de2cf4e80f0c6802f9a44989e6b1ad973b94849e76b1745f6d87144f517"
+checksum = "3152a88a0500991398f108a222db2fe7675d82108076cada75ddde082722b67a"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -1509,9 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.13.28"
+version = "0.13.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1b6b90dbfe7a4c7962c21732cc403f071bb795d93c5a82bce5290e31b3a9b5"
+checksum = "8b30c1e977cbd3148e7bf5e27ca2c6ae105c23ec6aeefa8e227a2b2beb5c954d"
 dependencies = [
  "anyhow",
  "miette",
@@ -1554,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.23.11"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ac8c26ad130c9ad96fe3505b20d4248e018729f9ea3195d6ea69d388b4b57f"
+checksum = "ab16771f5678559d7ae02cfc11f4a1fe3a2cef9ec884bb5618514e51a4111804"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -1628,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -1647,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.31.29"
+version = "0.31.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fa8d91f6555e4f80d119c66da232e8f998d6301c3c3b632f5b7141515264db"
+checksum = "2c2ff385007188b55b331858b8560d7bfe43b2ae56a3a500c0ef5aae7d482443"
 dependencies = [
  "ansi_term",
  "difference",
@@ -1849,9 +1848,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-id"
@@ -1982,45 +1981,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "ast_node"
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -739,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
@@ -873,11 +873,20 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1111,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "7434af0dc1cbd59268aa98b4c22c131c0584d2232f6fb166efb993e2832e896a"
 dependencies = [
  "itoa",
  "ryu",
@@ -1178,6 +1187,19 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
 
 [[package]]
 name = "static_assertions"
@@ -1260,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "swc-plugin-hello"
-version = "0.1.0"
+version = "0.1.7"
 dependencies = [
  "serde",
  "swc_core",
@@ -1283,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.29.28"
+version = "0.29.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4627e86f60ca7b81dbd2cfa571870236ffaae5c79920639b42935e94826c9b2c"
+checksum = "a97e491d31418cd33fea58e9f893316fc04b30e2b5d0e750c066e2ba4907ae54"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1316,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.59.1"
+version = "0.59.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dca0a0e3c0eb88f2a4788078dbad7c6d18ce9c0081d93600032f2aa4dba17c4"
+checksum = "c935259a32e5b80645fa57fffd6380946d49d5786a2d98f0ce832672b9b9f76f"
 dependencies = [
  "once_cell",
  "swc_atoms",
@@ -1335,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.96.2"
+version = "0.96.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7d0ce5a6462815ef8cb549f1be100c95c599171777398f32bbf275969f9518"
+checksum = "a887102d5595b557261aa4bde35f3d71906fba674d4b79cd5c59b4155b12ee2d"
 dependencies = [
  "bitflags",
  "is-macro",
@@ -1353,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.129.6"
+version = "0.129.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "007ecd4d3b1fa3c08d6c226d9905d88abb9b97105efba182478da6d0d55d5eac"
+checksum = "02094481926efe130d49adfe339b2b3dd76824cfc20afc26d09f2eaac219f6ae"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -1385,9 +1407,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.124.3"
+version = "0.124.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "855e61613186afae0344ebf602b0c83bc4227f262ef63e5fae1e503077ea0abf"
+checksum = "ba44bbab327abbac33481046987acb481cd8a0d43ec7dcdad08a76e5abec39ee"
 dependencies = [
  "either",
  "enum_kind",
@@ -1395,6 +1417,7 @@ dependencies = [
  "num-bigint",
  "serde",
  "smallvec",
+ "stacker",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -1416,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.116.2"
+version = "0.116.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bae98277e96f4b4b98d41c277cc8645dc7b86dc85ac0f3c83575ae12a6068cb"
+checksum = "0ac8e727d56c1a7f339213e6eccae10766eeec2dc9270add75db30fff791d28f"
 dependencies = [
  "better_scoped_tls",
  "bitflags",
@@ -1438,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.119.2"
+version = "0.119.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1de89253e3859306997c75adcce0ea8b9032ea488f3027eb4d70090334a5b80"
+checksum = "053f7ae9dca3fd45d472b72231ad9c086d5e5fb5057ee4525b0ab7267178ecd7"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1464,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.107.3"
+version = "0.107.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc62641e475f0cfdef0b63f4f68a94b8762109cd92a0382f69e5d74be5afd5b"
+checksum = "820687453555366f187cc927b39bbad4137da80ac067763e56471db92d485b78"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -1482,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.82.2"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3152a88a0500991398f108a222db2fe7675d82108076cada75ddde082722b67a"
+checksum = "6b2ee0f4b61d6c426189d0d9da1333705ff3bc4513fb63633ca254595a700f75"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -1508,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.13.29"
+version = "0.13.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b30c1e977cbd3148e7bf5e27ca2c6ae105c23ec6aeefa8e227a2b2beb5c954d"
+checksum = "8cab7b4d57a38aa721d3b64896f07198567e0d26fa15517eeddc52560f7f7ab8"
 dependencies = [
  "anyhow",
  "miette",
@@ -1553,9 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16771f5678559d7ae02cfc11f4a1fe3a2cef9ec884bb5618514e51a4111804"
+checksum = "40bf5af63d89dd7ef4742695d1143156258debdc74af78973566c5d99c4a65c1"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -1578,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82f2bcb7223e185c4c7cbf5e0c1207dec6d2bfd5e72e3fb7b3e8d179747e9130"
+checksum = "470a1963cf182fdcbbac46e3a7fd2caf7329da0e568d3668202da9501c880e16"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -1588,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb1f3561674d84947694d41fb6d5737d19539222779baeac1b3a071a2b29428"
+checksum = "6098b717cfd4c85f5cddec734af191dbce461c39975ed567c32ac6d0c6d61a6d"
 dependencies = [
  "Inflector",
  "pmutil",
@@ -1646,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.31.30"
+version = "0.31.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c2ff385007188b55b331858b8560d7bfe43b2ae56a3a500c0ef5aae7d482443"
+checksum = "0a9de85488135d7351345aab356bc08ae9a23ca4d1d064238aa4e8198fa613c8"
 dependencies = [
  "ansi_term",
  "difference",
@@ -1758,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tracing"
@@ -1966,9 +1989,18 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "enum-iterator"
@@ -1268,9 +1268,9 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a49e93996e1c1cfdb641cd94888da545d440ff6cada04155ef118adee620c1"
+checksum = "731cf66bd8e11030f056f91f9d8af77f83ec4377ff04d1670778a57d1607402a"
 dependencies = [
  "once_cell",
  "rkyv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc-plugin-hello"
-version = "0.1.0"
+version = "0.1.7"
 edition = "2021"
 
 [lib]
@@ -20,7 +20,7 @@ strip = "symbols"
 
 [dependencies]
 serde = "1"
-swc_core = { version = "0.59.*", features = ["ecma_plugin_transform"] }
+swc_core = { version = "0.59.21", features = ["ecma_plugin_transform"] }
 
 # .cargo/config defines few alias to build plugin.
 # cargo build-wasi generates wasm-wasi32 binary

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc-plugin-hello"
-version = "0.1.7"
+version = "0.1.10"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ strip = "symbols"
 
 [dependencies]
 serde = "1"
-swc_core = { version = "0.53.*", features = ["ecma_plugin_transform"] }
+swc_core = { version = "0.59.*", features = ["ecma_plugin_transform"] }
 
 # .cargo/config defines few alias to build plugin.
 # cargo build-wasi generates wasm-wasi32 binary

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "swc-plugin-hello",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Hello world rust swc plugin",
     "author": "Antony",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swc-plugin-hello",
-  "version": "0.1.7",
+  "version": "0.1.10",
   "description": "Hello world rust swc plugin",
   "author": "Antony",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-    "name": "swc-plugin-hello",
-    "version": "0.1.1",
-    "description": "Hello world rust swc plugin",
-    "author": "Antony",
-    "license": "MIT",
-    "keywords": [
-        "swc-plugin"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/antonybudianto/swc-plugin-hello"
-    },
-    "main": "target/wasm32-wasi/release/swc_plugin_hello.wasm",
-    "scripts": {},
-    "files": []
+  "name": "swc-plugin-hello",
+  "version": "0.1.7",
+  "description": "Hello world rust swc plugin",
+  "author": "Antony",
+  "license": "MIT",
+  "keywords": [
+    "swc-plugin"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/antonybudianto/swc-plugin-hello"
+  },
+  "main": "target/wasm32-wasi/release/swc_plugin_hello.wasm",
+  "scripts": {},
+  "files": []
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,6 @@
 [toolchain]
 # https://github.com/swc-project/swc/issues/6807
-channel = "1.67.0"
+channel = "1.66.0"
+components = [ "rustfmt" ]
 targets = [ "wasm32-wasi", "wasm32-unknown-unknown" ]
 profile = "default"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
+use swc_core::common::util::take::Take;
+use swc_core::ecma::ast::Pat::Ident;
+use swc_core::ecma::ast::{Decl, ModuleItem, Stmt};
 use swc_core::ecma::{
-    ast::{Ident, Program},
+    ast::{Program, VarDeclarator},
     transforms::testing::test,
     visit::{as_folder, FoldWith, VisitMut, VisitMutWith},
 };
-
 use swc_core::plugin::{plugin_transform, proxies::TransformPluginProgramMetadata};
 
 pub struct TransformVisitor;
@@ -13,20 +15,102 @@ impl VisitMut for TransformVisitor {
     // A comprehensive list of possible visitor methods can be found here:
     // https://rustdoc.swc.rs/swc_ecma_visit/trait.VisitMut.html
 
-    // fn visit_mut_bin_expr(&mut self, e: &mut BinExpr) {
-    //     e.visit_mut_children_with(self);
+    fn visit_mut_export_decl(&mut self, v: &mut swc_core::ecma::ast::ExportDecl) {
+        v.visit_mut_children_with(self);
 
-    //     if e.op == op!("===") {
-    //         e.left = Box::new(Ident::new("kdy1".into(), e.left.span()).into());
-    //     }
-    // }
+        // v.decl.take();
 
-    fn visit_mut_ident(&mut self, n: &mut Ident) {
-        n.visit_mut_children_with(self);
+        // match &v.decl {
+        //     Decl::Var(vd) => {
+        //         match &vd.decls[0].name {
+        //             Ident(i) => {
+        //                 println!("LOG:{}", &*i.sym);
+        //                 if &*i.sym == "getServerSideProps" {
+        //                     println!(">> removed!");
+        //                     v.span.take();
+        //                     // v.decl.take();
+        //                 }
+        //             }
+        //             _ => {}
+        //         }
+        //     }
+        //     _ => {}
+        // }
+    }
 
-        if n.sym.to_string() == "__DEV__" {
-            n.sym = "false".into();
+    fn visit_mut_var_declarator(&mut self, v: &mut VarDeclarator) {
+        // This is not required in this example, but you typically need this.
+        v.visit_mut_children_with(self);
+
+        // v.name is `Pat`.
+        // See https://rustdoc.swc.rs/swc_ecma_ast/enum.Pat.html
+        match &v.name {
+            // If we want to delete the node, we should return false.
+            //
+            // Note the `&*` before i.sym.
+            // The type of symbol is `JsWord`, which is an interned string.
+            Ident(i) => {
+                if &*i.sym == "getServerSideProps" {
+                    // Take::take() is a helper function, which stores invalid value in the node.
+                    // For Pat, it's `Pat::Invalid`.
+                    v.name.take();
+                }
+            }
+            _ => {
+                // Noop if we don't want to delete the node.
+            }
         }
+    }
+
+    fn visit_mut_var_declarators(&mut self, vars: &mut Vec<VarDeclarator>) {
+        vars.visit_mut_children_with(self);
+
+        vars.retain(|node| {
+            // We want to remove the node, so we should return false.
+            if node.name.is_invalid() {
+                return false;
+            }
+
+            // Return true if we want to keep the node.
+            true
+        });
+    }
+
+    fn visit_mut_stmt(&mut self, s: &mut Stmt) {
+        s.visit_mut_children_with(self);
+
+        match s {
+            Stmt::Decl(Decl::Var(var)) => {
+                if var.decls.is_empty() {
+                    // Variable declaration without declarator is invalid.
+                    //
+                    // After this, `s` becomes `Stmt::Empty`.
+                    s.take();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn visit_mut_stmts(&mut self, stmts: &mut Vec<Stmt>) {
+        stmts.visit_mut_children_with(self);
+
+        // We remove `Stmt::Empty` from the statement list.
+        // This is optional, but it's required if you don't want extra `;` in output.
+        stmts.retain(|s| {
+            // We use `matches` macro as this match is trivial.
+            !matches!(s, Stmt::Empty(..))
+        });
+    }
+
+    fn visit_mut_module_items(&mut self, stmts: &mut Vec<ModuleItem>) {
+        stmts.visit_mut_children_with(self);
+
+        // This is also required, because top-level statements are stored in `Vec<ModuleItem>`.
+        stmts.retain(|s| {
+            // We use `matches` macro as this match is trivial.
+            !matches!(s, ModuleItem::Stmt(Stmt::Empty(..)))
+        });
     }
 }
 
@@ -66,6 +150,21 @@ test!(
     Default::default(),
     |_| as_folder(TransformVisitor),
     simple_transform_global_var,
-    r#"let isDev = __DEV__;"#,
-    r#"let isDev = false;"#
+    r#"
+export const getServerSideProps = async context => {
+    return {
+        props: {
+            a: 1,
+        },
+    };
+};
+const Home = () => {
+    return null;
+};
+export default Home;"#,
+    r#"
+const Home = () => {
+    return null;
+};
+export default Home;"#
 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,33 +20,53 @@ impl VisitMut for TransformVisitor {
     // A comprehensive list of possible visitor methods can be found here:
     // https://rustdoc.swc.rs/swc_ecma_visit/trait.VisitMut.html
 
-    fn visit_mut_var_declarator(&mut self, v: &mut VarDeclarator) {
-        // This is not required in this example, but you typically need this.
-        v.visit_mut_children_with(self);
-
-        // v.name is `Pat`.
-        // See https://rustdoc.swc.rs/swc_ecma_ast/enum.Pat.html
-        match &v.name {
-            // If we want to delete the node, we should return false.
-            //
-            // Note the `&*` before i.sym.
-            // The type of symbol is `JsWord`, which is an interned string.
-            Ident(i) => {
-                if &*i.sym == EXPORT_NAME_GET_SERVER_PROPS
-                    || &*i.sym == EXPORT_NAME_GET_INITIAL_PROPS
-                    || &*i.sym == EXPORT_NAME_GET_STATIC_CONFIG
-                    || &*i.sym == EXPORT_NAME_GET_STATIC_PROPS
-                {
-                    // Take::take() is a helper function, which stores invalid value in the node.
-                    // For Pat, it's `Pat::Invalid`.
-                    v.name.take();
+    fn visit_mut_export_decl(&mut self, v: &mut swc_core::ecma::ast::ExportDecl) {
+        match &v.decl {
+            Decl::Var(vd) => match &vd.decls[0].name {
+                Ident(i) => {
+                    if &*i.sym == EXPORT_NAME_GET_SERVER_PROPS
+                        || &*i.sym == EXPORT_NAME_GET_INITIAL_PROPS
+                        || &*i.sym == EXPORT_NAME_GET_STATIC_CONFIG
+                        || &*i.sym == EXPORT_NAME_GET_STATIC_PROPS
+                    {
+                        v.decl.take();
+                    }
                 }
-            }
-            _ => {
-                // Noop if we don't want to delete the node.
-            }
+                _ => {}
+            },
+            _ => {}
         }
     }
+
+    /**
+     * We can also use this, but this one will also deletes non-export variables/fn
+     */
+    // fn visit_mut_var_declarator(&mut self, v: &mut VarDeclarator) {
+    //     v.visit_mut_children_with(self);
+
+    //     // v.name is `Pat`.
+    //     // See https://rustdoc.swc.rs/swc_ecma_ast/enum.Pat.html
+    //     match &v.name {
+    //         // If we want to delete the node, we should return false.
+    //         //
+    //         // Note the `&*` before i.sym.
+    //         // The type of symbol is `JsWord`, which is an interned string.
+    //         Ident(i) => {
+    //             if &*i.sym == EXPORT_NAME_GET_SERVER_PROPS
+    //                 || &*i.sym == EXPORT_NAME_GET_INITIAL_PROPS
+    //                 || &*i.sym == EXPORT_NAME_GET_STATIC_CONFIG
+    //                 || &*i.sym == EXPORT_NAME_GET_STATIC_PROPS
+    //             {
+    //                 // Take::take() is a helper function, which stores invalid value in the node.
+    //                 // For Pat, it's `Pat::Invalid`.
+    //                 v.name.take();
+    //             }
+    //         }
+    //         _ => {
+    //             // Noop if we don't want to delete the node.
+    //         }
+    //     }
+    // }
 
     fn visit_mut_var_declarators(&mut self, vars: &mut Vec<VarDeclarator>) {
         vars.visit_mut_children_with(self);
@@ -107,18 +127,6 @@ pub fn process_transform(program: Program, _metadata: TransformPluginProgramMeta
     program.fold_with(&mut as_folder(TransformVisitor))
 }
 
-// An example to test plugin transform.
-// Recommended strategy to test plugin's transform is verify
-// the Visitor's behavior, instead of trying to run `process_transform` with mocks
-// unless explicitly required to do so.
-// test!(
-//     Default::default(),
-//     |_| as_folder(TransformVisitor),
-//     simple_transform_kdy1,
-//     r#"foo === bar;"#,
-//     r#"kdy1 === bar;"#
-// );
-
 test!(
     Default::default(),
     |_| as_folder(TransformVisitor),
@@ -136,6 +144,36 @@ const Home = () => {
 };
 export default Home;"#,
     r#"
+const Home = () => {
+    return null;
+};
+export default Home;"#
+);
+
+test!(
+    Default::default(),
+    |_| as_folder(TransformVisitor),
+    not_delete_non_export_getserversideprops,
+    r#"
+const getServerSideProps = async context => {
+    return {
+        props: {
+            a: 1,
+        },
+    };
+};
+const Home = () => {
+    return null;
+};
+export default Home;"#,
+    r#"
+const getServerSideProps = async context => {
+    return {
+        props: {
+            a: 1,
+        },
+    };
+};
 const Home = () => {
     return null;
 };


### PR DESCRIPTION
There is issue on latest stable Rust channel with swc, so need to use old Rust (1.66.0) 
- https://github.com/swc-project/swc/issues/6807